### PR TITLE
Tiny.cloud/CKEditor support

### DIFF
--- a/Sources/FeatherCore/Bundles/Admin/Templates/Fields/Textarea-ckeditor.html
+++ b/Sources/FeatherCore/Bundles/Admin/Templates/Fields/Textarea-ckeditor.html
@@ -1,0 +1,11 @@
+<section class="m:bottom">
+    <script src="https://cdn.ckeditor.com/4.15.1/standard/ckeditor.js"></script>
+    <label for="#(field.id)">#(field.label ?? field.id.capitalized())#if(field.required ?? false):<span class="required">*</span>#endif#if(field.more ?? false): <span class="more">(#(field.more))</span>#endif</label>
+    <textarea name="#(field.id)" class="#(field.size)"#if(field.required ?? false): aria-required="true"#endif>#(field.data.value)</textarea>
+    #if(field.data.error != nil):
+    <span class="error">#(field.data.error)</span>
+    #endif
+    <script>
+      CKEDITOR.replace( '#(field.id)' );
+   </script>
+</section>

--- a/Sources/FeatherCore/Bundles/Admin/Templates/Fields/Textarea-tinymce.html
+++ b/Sources/FeatherCore/Bundles/Admin/Templates/Fields/Textarea-tinymce.html
@@ -1,0 +1,16 @@
+<section class="m:bottom">
+     <script src='https://cdn.tiny.cloud/1/#($system["site.tiny.apikey"])/tinymce/5/tinymce.min.js' referrerpolicy="origin">
+     </script>
+     <script>
+       tinymce.init({
+         selector: '\#tinymce-#(field.id)',
+         plugins: '#($system["site.tiny.plugins"] ?? "print preview fullpage searchreplace autolink directionality visualblocks visualchars fullscreen image link media template codesample table charmap hr pagebreak nonbreaking anchor insertdatetime advlist lists textcolor wordcount imagetools contextmenu colorpicker textpattern")',
+         toolbar: '#($system["site.tiny.toolbar"] ?? "styleselect bold italic underline | forecolor backcolor | alignleft aligncenter alignright | bullist numlist outdent indent | link image table youtube giphy | codesample code")'
+        });
+     </script>
+    <label for="#(field.id)">#(field.label ?? field.id.capitalized())#if(field.required ?? false):<span class="required">*</span>#endif#if(field.more ?? false): <span class="more">(#(field.more))</span>#endif</label>
+    <textarea id="tinymce-#(field.id)" name="#(field.id)" class="#(field.size)"#if(field.required ?? false): aria-required="true"#endif>#(field.data.value)</textarea>
+    #if(field.data.error != nil):
+    <span class="error">#(field.data.error)</span>
+    #endif
+</section>


### PR DESCRIPTION
Hello again,

another thing I am missing, is a visual HTML editor. 

I default it to CKEditor which work out of the box. 

We can also support https://www.tiny.cloud
**with 3 system variables:**
site.tiny.apikey (It will be use to discover if the site is configured for it later in feather)
site.tiny.plugins
site.tiny.toolbar

Let me know what you think.

Thanks,

Denis