### PR TITLE
Linux system are looking a lot more into filename case. This was caus…

### DIFF
--- a/Sources/FeatherCore/Modules/Frontend/FrontendModule.swift
+++ b/Sources/FeatherCore/Modules/Frontend/FrontendModule.swift
@@ -108,7 +108,7 @@ final class FrontendModule: ViperModule {
         let homePage = FrontendPageModel(title: "Home", content: "[frontend-home-page]")
 
         /// create a sample about page
-        let aboutPage = FrontendPageModel(title: "About", content: FrontendModule.sample(asset: "about.html"))
+        let aboutPage = FrontendPageModel(title: "About", content: FrontendModule.sample(asset: "About.html"))
         pageModels.append(aboutPage)
 
         /// we persist the pages to the database


### PR DESCRIPTION
@tib 
This PR will fix the Linux initialisation problem.
The Mac doesn't care about the case "about.html" but on Linux machine it cause the exception

Kind Regards,

Denis

```
0x7f04692080f9, closure #1 (Swift.Int32) -> () in static Backtrace.Backtrace.install() -> () at /home/ubuntu/feather/.build/checkouts/swift-backtrace/Sources/Backtrace/Backtrace.swift:67
0x7f0469208108, @objc closure #1 (Swift.Int32) -> () in static Backtrace.Backtrace.install() -> () at /home/ubuntu/feather/<compiler-generated>:0
0x7f04682153bf
0x7f04683971a2
0x7f046a509a50, static (extension in ViperKit):ViperKit.ViperModule.sample(asset: Swift.String) -> Swift.String at /home/ubuntu/feather/.build/checkouts/viper-kit/Sources/ViperKit/Viper/ViperModule.swift:115
0x7f046980bed4, FeatherCore.FrontendModule.modelInstallHook(args: Swift.Dictionary<Swift.String, Any>) -> NIO.EventLoopFuture<()> at /home/ubuntu/feather/.build/checkouts/feather-core/Sources/FeatherCore/Modules/Frontend/FrontendModule.swift:111
0x7f046980a499, implicit closure #2 (Swift.Dictionary<Swift.String, Any>) -> NIO.EventLoopFuture<()> in implicit closure #1 (FeatherCore.FrontendModule) -> (Swift.Dictionary<Swift.String, Any>) -> NIO.EventLoopFuture<()> in FeatherCore.FrontendModule.boot(Vapor.Application) throws -> () at /home/ubuntu/feather/.build/checkouts/feather-core/Sources/FeatherCore/Modules/Frontend/FrontendModule.swift:32
0x7f046922483f, reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Swift.Dictionary<Swift.String, Any>) -> (@owned NIO.EventLoopFuture<()>) to @escaping @callee_guaranteed (@guaranteed Swift.Dictionary<Swift.String, Any>) -> (@out NIO.EventLoopFuture<()>) at /home/ubuntu/feather/<compiler-generated>:0
0x7f046980c7b0, partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Swift.Dictionary<Swift.String, Any>) -> (@owned NIO.EventLoopFuture<()>) to @escaping @callee_guaranteed (@guaranteed Swift.Dictionary<Swift.String, Any>) -> (@out NIO.EventLoopFuture<()>) at /home/ubuntu/feather/<compiler-generated>:0
```